### PR TITLE
feat(portal): API token (Bearer) auth + Helm ui.token

### DIFF
--- a/chart/templates/portal.yaml
+++ b/chart/templates/portal.yaml
@@ -46,6 +46,14 @@ spec:
           value: {{ .Values.ui.vcs.baseUrl | quote }}
         - name: VCS_PUBLIC_BASE_URL
           value: {{ .Values.ui.vcs.publicBaseUrl | quote }}
+        {{- if .Values.ui.token.enabled }}
+        - name: API_TOKEN_ENABLED
+          value: "true"
+        - name: API_TOKEN_USER
+          value: {{ .Values.ui.token.user | quote }}
+        - name: API_TOKEN
+          value: {{ .Values.ui.token.value | quote }}
+        {{- end }}
         resources: {}
         lifecycle:
           postStart:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -230,3 +230,9 @@ ui:
     enabled: false
     host: localhost
     issuer: letsencrypt
+  # When enabled, portal accepts Authorization: Bearer <token> as the given DB user (same as UI login).
+  # TODO: load API_TOKEN from a Kubernetes Secret instead of plain values.
+  token:
+    enabled: true
+    user: system
+    value: litefunctionsxxxtoken

--- a/portal/internal/auth/adaptors/selectors.go
+++ b/portal/internal/auth/adaptors/selectors.go
@@ -32,6 +32,14 @@ func convertDBCredentialToWebauthn(c Credential) webauthn.Credential {
 	}
 }
 
+func (db *WebauthnStore) GetUserByName(userName string) (string, []byte, error) {
+	u, err := db.GetUser(userName)
+	if err != nil {
+		return "", nil, err
+	}
+	return u.Name, u.ID, nil
+}
+
 func (db *WebauthnStore) GetUser(userName string) (*auth.User, error) {
 	u, err := db.queries.GetUserByName(context.Background(), userName)
 	if err != nil {

--- a/portal/internal/auth/spec.go
+++ b/portal/internal/auth/spec.go
@@ -29,6 +29,9 @@ type PasskeyStore interface {
 
 	// User authentication session methods
 	SessionStore
+
+	// GetUserByName returns the canonical name and WebAuthn user ID for API token auth.
+	GetUserByName(userName string) (name string, id []byte, err error)
 }
 
 func NewWebauthn() (*webauthn.WebAuthn, error) {

--- a/portal/pkg/config.go
+++ b/portal/pkg/config.go
@@ -29,6 +29,12 @@ type Settings struct {
 	VcsPublicBaseUrl        string `env:"VCS_PUBLIC_BASE_URL"`
 	OperatorUrl             string `env:"OPERATOR_URL" default:"litefunctions-operator:50051"`
 	IngestorUrl             string `env:"INGESTOR_URL" default:"http://litefunctions-ingestor:3000"`
+
+	// API_TOKEN_ENABLED: when true, Authorization: Bearer <API_TOKEN> authenticates
+	// as user API_TOKEN_USER (must exist in DB), bypassing session cookies.
+	APITokenEnabled bool   `env:"API_TOKEN_ENABLED" default:"false"`
+	APIToken        string `env:"API_TOKEN"`
+	APITokenUser    string `env:"API_TOKEN_USER" default:"system"`
 }
 
 var (

--- a/portal/pkg/server/middleware/auth.go
+++ b/portal/pkg/server/middleware/auth.go
@@ -1,39 +1,102 @@
 package middleware
 
 import (
+	"crypto/subtle"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/ashupednekar/litefunctions/portal/internal/auth"
+	"github.com/ashupednekar/litefunctions/portal/pkg"
 	"github.com/gin-gonic/gin"
 )
 
-func AuthMiddleware(sessionStore auth.SessionStore) gin.HandlerFunc {
+func constantTimeEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func parseBearerToken(h string) (string, bool) {
+	h = strings.TrimSpace(h)
+	const prefix = "Bearer "
+	if len(h) < len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return "", false
+	}
+	tok := strings.TrimSpace(h[len(prefix):])
+	if tok == "" {
+		return "", false
+	}
+	return tok, true
+}
+
+func authRequiredFailure(c *gin.Context) {
+	if strings.HasPrefix(c.Request.URL.Path, "/api/") {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	} else {
+		c.Redirect(http.StatusFound, "/?redirect="+c.Request.URL.Path)
+	}
+	c.Abort()
+}
+
+// tryAPIBearerAuth handles Authorization: Bearer when API_TOKEN_ENABLED is set.
+// Returns true if the request was fully handled (Next or Abort).
+func tryAPIBearerAuth(c *gin.Context, store auth.PasskeyStore) bool {
+	if !pkg.Cfg.APITokenEnabled || pkg.Cfg.APIToken == "" {
+		return false
+	}
+	tok, hasBearer := parseBearerToken(c.GetHeader("Authorization"))
+	if !hasBearer {
+		return false
+	}
+	if !constantTimeEqual(tok, pkg.Cfg.APIToken) {
+		log.Printf("[WARN] invalid API token attempt for %s", c.Request.URL.Path)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		c.Abort()
+		return true
+	}
+	userName := pkg.Cfg.APITokenUser
+	if userName == "" {
+		userName = "system"
+	}
+	name, userID, err := store.GetUserByName(userName)
+	if err != nil {
+		log.Printf("[ERROR] API token user %q not found: %v", userName, err)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "api token user not found"})
+		c.Abort()
+		return true
+	}
+	c.Set("userID", userID)
+	c.Set("userName", name)
+	c.Next()
+	return true
+}
+
+func AuthMiddleware(store auth.PasskeyStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if tryAPIBearerAuth(c, store) {
+			return
+		}
 
 		sessionID, err := c.Cookie(auth.SessionCookieName)
 		if err != nil {
 			log.Printf("[DEBUG] No session cookie found: %v", err)
-
-			c.Redirect(http.StatusFound, "/?redirect="+c.Request.URL.Path)
-			c.Abort()
+			authRequiredFailure(c)
 			return
 		}
 
-		userName, userID, found, err := sessionStore.GetUserSession(sessionID)
+		userName, userID, found, err := store.GetUserSession(sessionID)
 		if err != nil {
 			log.Printf("[ERROR] Error retrieving session: %v", err)
-			c.Redirect(http.StatusFound, "/?redirect="+c.Request.URL.Path)
-			c.Abort()
+			authRequiredFailure(c)
 			return
 		}
 
 		if !found {
 			log.Printf("[DEBUG] Session not found or expired")
-
 			c.SetCookie(auth.SessionCookieName, "", -1, "/", "", false, true)
-			c.Redirect(http.StatusFound, "/?redirect="+c.Request.URL.Path)
-			c.Abort()
+			authRequiredFailure(c)
 			return
 		}
 
@@ -43,14 +106,30 @@ func AuthMiddleware(sessionStore auth.SessionStore) gin.HandlerFunc {
 	}
 }
 
-func OptionalAuthMiddleware(sessionStore auth.SessionStore) gin.HandlerFunc {
+func OptionalAuthMiddleware(store auth.PasskeyStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if pkg.Cfg.APITokenEnabled && pkg.Cfg.APIToken != "" {
+			tok, ok := parseBearerToken(c.GetHeader("Authorization"))
+			if ok && constantTimeEqual(tok, pkg.Cfg.APIToken) {
+				userName := pkg.Cfg.APITokenUser
+				if userName == "" {
+					userName = "system"
+				}
+				if name, userID, err := store.GetUserByName(userName); err == nil {
+					c.Set("userID", userID)
+					c.Set("userName", name)
+					c.Set("authenticated", true)
+				}
+				c.Next()
+				return
+			}
+		}
 		sessionID, err := c.Cookie(auth.SessionCookieName)
 		if err == nil {
-			userName, userID, found, err := sessionStore.GetUserSession(sessionID)
+			userName, userID, found, err := store.GetUserSession(sessionID)
 			if err == nil && found {
 				c.Set("userID", userID)
-			  c.Set("userName", userName)
+				c.Set("userName", userName)
 				c.Set("authenticated", true)
 			}
 		}


### PR DESCRIPTION
Adds `Authorization: Bearer` support for programmatic access (same DB user as `API_TOKEN_USER`). Helm wires `API_TOKEN` from `ui.token.value` (TODO: use Kubernetes Secret).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API bearer-token authentication, enabling users to authenticate via bearer tokens in addition to existing passkey methods.

* **Configuration**
  * New settings introduced to enable and configure API token authentication with user mapping support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->